### PR TITLE
Adds .toLowerCase to bookshelves filter

### DIFF
--- a/src/goodreads_inject.js
+++ b/src/goodreads_inject.js
@@ -82,7 +82,7 @@ function getOverdriveAvailability() {
 	var book = $("h1#bookTitle.bookTitle");
 	var booklist = $("a.bookTitle");
 	var bookshelves = $("h3").filter(function() {
-		return $(this).text().indexOf("bookshelves") >= 0;
+        return $(this).text().toLowerCase().indexOf("bookshelves") >= 0;
 	});
 
 	// if a single book page


### PR DESCRIPTION
This fixes #23 for me.

`.indexOf("bookshelves")` fails to find any matches. My thought is that Goodreads was probably using CSS to titlecase the `h3`, and now they are using proper case in the HTML, causing this line to fail. Using `.toLowerCase()` normalizes the text so if they were to change it again it should still work.