### PR TITLE
Updates bookshelves filter to look for new element

### DIFF
--- a/src/goodreads_inject.js
+++ b/src/goodreads_inject.js
@@ -81,7 +81,7 @@ function getOverdriveAvailability() {
 	// check for tags on either a single book review page or the bookshelf page
 	var book = $("h1#bookTitle.bookTitle");
 	var booklist = $("a.bookTitle");
-	var bookshelves = $("h3").filter(function() {
+    	var bookshelves = $("#shelvesSection .sectionHeader").filter(function() {
 		return $(this).text().toLowerCase().indexOf("bookshelves") >= 0;
 	});
 


### PR DESCRIPTION
This closes #27.

Looks like the Goodreads UI updated to no longer use `h3` elements, so I updated the filter to use the new elements.